### PR TITLE
fix: ensure pkce code verifier is stored

### DIFF
--- a/services/auth-service.js
+++ b/services/auth-service.js
@@ -121,6 +121,7 @@ class AuthService extends EventEmitter {
             redirect_to: 'myapp://auth-callback'  // Ensure this parameter is set
           }
         },
+        flowType: 'pkce'
       });
 
       if (error) throw error;


### PR DESCRIPTION
## Summary
- ensure Google OAuth login requests PKCE flow so code verifier is saved

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689af38fe268832aaac0f3298b4dd898